### PR TITLE
support tuple/vector of arrays for mosaicview -- a slow version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.2.0-DEV"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.0-DEV"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -211,6 +211,25 @@ julia> mosaicview(A, -1, nrow=2, npad=1, rowmajor=true)
   4   4   4  -1   5   5   5  -1  -1  -1  -1
 ```
 
+`mosaicview` also supports array/tuple of array inputs:
+
+```julia
+julia> A = [i*ones(Int, 2, 3) for i in 1:4]
+4-element Array{Array{Int64,2},1}:
+ [1 1 1; 1 1 1]
+ [2 2 2; 2 2 2]
+ [3 3 3; 3 3 3]
+ [4 4 4; 4 4 4]
+
+ julia> mosaicview(A, nrow=3)
+ 6×6 MosaicView{Int64,4,...}:
+  1  1  1  4  4  4
+  1  1  1  4  4  4
+  2  2  2  0  0  0
+  2  2  2  0  0  0
+  3  3  3  0  0  0
+  3  3  3  0  0  0
+```
 
 [pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/M/MosaicViews.svg
 [pkgeval-url]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html

--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -2,7 +2,6 @@ module MosaicViews
 
 using ImageCore
 using PaddedViews
-using OffsetArrays
 
 export
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,43 @@ end
     @test_throws ArgumentError mosaicview(rand(2))
     @test_throws ArgumentError mosaicview(rand(2,2))
 
+    @testset "Vector/Tuple of 2d Arrays input" begin
+        A = [i*ones(Int, 2, 3) for i in 1:4]
+
+        for B in (A, tuple(A...))
+            @test_throws ArgumentError mosaicview(B, nrow=0)
+            @test_throws ArgumentError mosaicview(B, ncol=0)
+            @test_throws ArgumentError mosaicview(B, nrow=1, ncol=1)
+
+            mv = mosaicview(B)
+            @test typeof(mv) <: MosaicView
+            @test eltype(mv) == eltype(eltype(B))
+            @test size(mv) == (8, 3)
+            @test @inferred(getindex(mv,3,1)) === 2
+            @test mv == [
+                1  1  1
+                1  1  1
+                2  2  2
+                2  2  2
+                3  3  3
+                3  3  3
+                4  4  4
+                4  4  4
+            ]
+
+            mv = mosaicview(B, nrow=2)
+            @test typeof(mv) <: MosaicView
+            @test eltype(mv) == eltype(eltype(B))
+            @test size(mv) == (4, 6)
+            @test mv == [
+             1  1  1  3  3  3
+             1  1  1  3  3  3
+             2  2  2  4  4  4
+             2  2  2  4  4  4
+            ]
+        end
+    end
+
     @testset "3D input" begin
         A = [(k+1)*l-1 for i in 1:2, j in 1:3, k in 1:2, l in 1:2]
         B = reshape(A, 2, 3, :)


### PR DESCRIPTION
It would be convenient to visualize a list/tuple of images of different sizes.

The pipeline isn't very efficient, for example, 2d images are concatenated to 3d images, and then piped into previous 3d mosaicview methods. In the future, we can directly implement a faster version without changing dimensions, but for now, it's still okay to use this slow version to ease some of the visualization work.

Said that, it's still possible to do a manual cat if performance is an issue.

Preview:

```julia
patch_sizes = ((28, 28), (32, 32), (40, 40))
colors = (RGB{N0f8}, Gray{N0f8})
imgs = [rand(rand(colors), rand(patch_sizes)) for i in 1:40]
mosaicview(imgs; nrow=6, npad=2)
```

![image](https://user-images.githubusercontent.com/8684355/76145709-e3cee680-60c6-11ea-95bc-2cd62830d152.png)
