### PR TITLE
remove ImageCore as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,16 @@ authors = ["Christof Stocker <stocker.christof@gmail.com>"]
 version = "0.2.0-DEV"
 
 [deps]
-ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 
 [compat]
-ImageCore = "0.8"
 PaddedViews = "0.4, 0.5"
 julia = "1"
 
 [extras]
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorVectorSpace", "Test"]
+test = ["ImageCore", "ColorVectorSpace", "Test"]

--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -1,6 +1,5 @@
 module MosaicViews
 
-using ImageCore
 using PaddedViews
 
 export
@@ -247,7 +246,7 @@ function mosaicview(A::AbstractArray{T,3},
         # before top-to-bottom. (note the swap of "ncol" and "nrow")
         res_dims = (size(A_pad,1), size(A_pad,2), ncol, nrow)
         A_tp = reshape(A_pad, res_dims)
-        permuteddimsview(A_tp, (1, 2, 4, 3))
+        PermutedDimsArray(A_tp, (1, 2, 4, 3))
     end
     # decrease size of the resulting MosaicView by npad to not have
     # a border on the right side and bottom side of the final mosaic.


### PR DESCRIPTION
ImageCore is quite a large dependency to such basic array package,
removing it makes it possible to introduce `MosaicViews` to Images.jl
ecosystem.