### PR TITLE
support mosaicview(As...; kwargs...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ julia> A = MNIST.convert2image(MNIST.traintensor(1:9))
 28×28×9 Array{Gray{Float64},3}:
 [...]
 
-julia> mosaicview(A, .5, nrow=2, npad=1, rowmajor=true)
+julia> mosaicview(A, fillvalue=.5, nrow=2, npad=1, rowmajor=true)
 57×144 MosaicViews.MosaicView{Gray{Float64},4,...}:
 [...]
 ```
@@ -128,7 +128,7 @@ In contrast to using the constructor of `MosaicView` directly,
 the function `mosaicview` also allows for a couple of convenience
 keywords.
 
-- The optional positional parameter `fill` defines the value that
+- The parameter `fillvalue` defines the value that
   that should be used for empty space. This can be padding caused
   by `npad`, or empty mosaic tiles in case the number of matrix
   slices in `A` is smaller than `nrow*ncol`.
@@ -202,7 +202,7 @@ julia> mosaicview(A, nrow=2, npad=1, rowmajor=true)
  4  4  4  0  5  5  5  0  0  0  0
  4  4  4  0  5  5  5  0  0  0  0
 
-julia> mosaicview(A, -1, nrow=2, npad=1, rowmajor=true)
+julia> mosaicview(A, fillvalue=-1, nrow=2, npad=1, rowmajor=true)
 5×11 MosaicViews.MosaicView{Int64,4,...}:
   1   1   1  -1   2   2   2  -1   3   3   3
   1   1   1  -1   2   2   2  -1   3   3   3
@@ -221,14 +221,23 @@ julia> A = [i*ones(Int, 2, 3) for i in 1:4]
  [3 3 3; 3 3 3]
  [4 4 4; 4 4 4]
 
- julia> mosaicview(A, nrow=3)
- 6×6 MosaicView{Int64,4,...}:
-  1  1  1  4  4  4
-  1  1  1  4  4  4
-  2  2  2  0  0  0
-  2  2  2  0  0  0
-  3  3  3  0  0  0
-  3  3  3  0  0  0
+julia> mosaicview(A, nrow=3)
+6×6 MosaicView{Int64,4,...}:
+ 1  1  1  4  4  4
+ 1  1  1  4  4  4
+ 2  2  2  0  0  0
+ 2  2  2  0  0  0
+ 3  3  3  0  0  0
+ 3  3  3  0  0  0
+
+julia> mosaicview(A..., nrow=3)
+6×6 MosaicView{Int64,4,...}:
+ 1  1  1  4  4  4
+ 1  1  1  4  4  4
+ 2  2  2  0  0  0
+ 2  2  2  0  0  0
+ 3  3  3  0  0  0
+ 3  3  3  0  0  0
 ```
 
 [pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/M/MosaicViews.svg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,7 @@ end
             @test_throws ArgumentError mosaicview(B, nrow=1, ncol=1)
 
             mv = mosaicview(B)
+            @test mosaicview(B...) == mv
             @test typeof(mv) <: MosaicView
             @test eltype(mv) == eltype(eltype(B))
             @test size(mv) == (8, 3)
@@ -100,6 +101,10 @@ end
              2  2  2  4  4  4
             ]
         end
+
+        @test mosaicview(A...) == mosaicview(A)
+        @test mosaicview(A..., nrow=2) == mosaicview(A, nrow=2)
+        @test mosaicview(A..., nrow=2, rowmajor=true) == mosaicview(A, nrow=2, rowmajor=true)
     end
 
     @testset "3D input" begin
@@ -130,6 +135,10 @@ end
         @test typeof(mv) <: MosaicView
         @test eltype(mv) == eltype(B)
         @test size(mv) == (4, 6)
+
+        @test mosaicview(B, B) == mosaicview(cat(B, B; dims=4))
+        @test mosaicview(B, B, nrow=2) == mosaicview(cat(B, B; dims=4), nrow=2)
+        @test mosaicview(B, B, nrow=2, rowmajor=true) == mosaicview(cat(B, B; dims=4), nrow=2, rowmajor=true)
     end
 
     @testset "4D input" begin
@@ -195,7 +204,7 @@ end
             5  5  5  0  0  0  0  0  0  0  0  0  0
             5  5  5  0  0  0  0  0  0  0  0  0  0
         ]
-        mv = mosaicview(A, -1.0, rowmajor=true, ncol=3, npad=1)
+        mv = mosaicview(A, fillvalue=-1.0, rowmajor=true, ncol=3, npad=1)
         @test typeof(mv) <: MosaicView
         @test eltype(mv) == eltype(A)
         @test size(mv) == (5, 11)
@@ -206,6 +215,10 @@ end
              5   5   5  -1  -1  -1  -1  -1  -1  -1  -1
              5   5   5  -1  -1  -1  -1  -1  -1  -1  -1
         ]
+
+        @test mosaicview(A, A) == mosaicview(cat(A, A; dims=5))
+        @test mosaicview(A, A, nrow=2) == mosaicview(cat(A, A; dims=4), nrow=2)
+        @test mosaicview(A, A, nrow=2, rowmajor=true) == mosaicview(cat(A, A; dims=4), nrow=2, rowmajor=true)
     end
 
     @testset "Colorant Array" begin
@@ -216,8 +229,17 @@ end
         mv = mosaicview(A, rowmajor=true, ncol=3)
         @test eltype(mv) == eltype(A)
         @test @inferred(getindex(mv, 3, 4)) == RGB(0,0,0)
-        mv = mosaicview(A, colorant"white", rowmajor=true, ncol=3)
+        mv = mosaicview(A, fillvalue=colorant"white", rowmajor=true, ncol=3)
         @test eltype(mv) == eltype(A)
         @test @inferred(getindex(mv, 3, 4)) == RGB(1,1,1)
     end
+end
+
+
+@testset "deprecations" begin
+    @info "deprecations are expected"
+    A = [(k+1)*l-1 for i in 1:2, j in 1:3, k in 1:2, l in 1:2]
+    mv_old = mosaicview(A, -1.0, rowmajor=true, ncol=3, npad=1)
+    mv_new = mosaicview(A, fillvalue=-1.0, rowmajor=true, ncol=3, npad=1)
+    @test mv_old == mv_new
 end


### PR DESCRIPTION
Address https://github.com/JuliaArrays/MosaicViews.jl/pull/6#discussion_r389303485

This allows the following usage

```julia
img1 = testimage("lena")
img2 = testimage("camera")
img3 = testimage("mand")

# a list of 2d arrays
x = mosaicview(img1, img2, img3)

# a list of 3d arrays
v1 = cat(paddedviews(colorant"black", img2, img1)...; dims=3)
v2 = cat(paddedviews(colorant"black", img1, img3)...; dims=3)
mosaicview(v1, v2) # in practice, v1 and v2 can be inputs/labels
```

This PR also deprecates the positional argument `fill` in favor of keyword parameter `fillvalue` (I should split them into two commits, but I messed it up...)


Preview:

```julia
imgs1 = rand(RGB{N0f8}, 28, 28, 12)
imgs2 = rand(Gray{N0f8}, 40, 40, 12)

mosaicview(imgs1, imgs2; ncol=8, npad=2)
```

![image](https://user-images.githubusercontent.com/8684355/76213473-bc525800-6245-11ea-85df-314f715d2a0c.png)


But note that if `imgs1` doesn't fit the cells, we can get the following results:

![image](https://user-images.githubusercontent.com/8684355/76213718-3a166380-6246-11ea-977e-ed60df5096f7.png)