### PR TITLE
center-shift padded images

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,17 @@ authors = ["Christof Stocker <stocker.christof@gmail.com>"]
 version = "0.2.0-DEV"
 
 [deps]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 
 [compat]
+OffsetArrays = "0.10, 0.11, 1"
 PaddedViews = "0.4, 0.5"
 julia = "1"
 
 [extras]
-ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ keywords.
   arranged left-to-right-top-to-bottom, instead of
   top-to-bottom-left-to-right (default).
 
+- If `center` is set to `true`, then the padded arrays will be shifted
+  to the center instead of in the top-left corner (default). This
+  parameter is only useful when arrays are of different sizes.
+
 ```julia
 julia> A = [k for i in 1:2, j in 1:3, k in 1:5]
 2×3×5 Array{Int64,3}:

--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -353,7 +353,7 @@ function _padded_cat(imgs; center, fillvalue, dims)
     else
         if center
             # TODO: ~1.5x slower than non-centered version
-            reduce(sym_paddedviews(zero(eltype(imgs[1])), imgs...)) do x, y
+            reduce(sym_paddedviews(fillvalue, imgs...)) do x, y
                 x = OffsetArray(x, 1 .- first.(axes(x)))
                 y = OffsetArray(y, 1 .- first.(axes(y)))
                 cat(x, y; dims=dims)

--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -329,10 +329,10 @@ function mosaicview(As::AbstractVector{T};
                fillvalue=fillvalue, kwargs...)
 end
 
-function mosaicview(As::Tuple{T, Vararg{T}};
+function mosaicview(As::Tuple;
                     fillvalue=zero(eltype(first(As))),
                     center=true,
-                    kwargs...) where {T <: AbstractArray}
+                    kwargs...)
     N = ndims(first(As))
     2 <= N || throw(ArgumentError("The given array must have dimensionality of N=2 or higher"))
     mosaicview(_padded_cat(As; center=center, fillvalue=fillvalue, dims=N+1);

--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -1,6 +1,7 @@
 module MosaicViews
 
 using PaddedViews
+using OffsetArrays
 
 export
 
@@ -99,7 +100,13 @@ end
 end
 
 """
-    mosaicview(A::AbstractArray; [fillvalue=<zero unit>], [npad=0], [nrow], [ncol], [rowmajor=false]) -> MosaicView
+    mosaicview(A::AbstractArray;
+               [fillvalue=<zero unit>],
+               [npad=0],
+               [nrow],
+               [ncol],
+               [rowmajor=false],
+               [center=true]) -> MosaicView
     mosaicview(A::AbstractArray...; kwargs...)
     mosaicview(As; kwargs...)
 
@@ -134,6 +141,10 @@ from a set of equally sized input images.
 - If `rowmajor` is set to `true`, then the slices will be
   arranged left-to-right-top-to-bottom, instead of
   top-to-bottom-left-to-right (default).
+
+- If `center` is set to `true`, then the padded arrays will be shifted
+  to the center instead of in the top-left corner (default). This
+  parameter is only useful when arrays are of different sizes.
 
 If the performance isn't an issue, `A` can also be a tuple/array
 of arrays, in this case all array elements will be padded to the
@@ -240,7 +251,8 @@ function mosaicview(A::AbstractArray{T,3};
                     npad = 0,
                     nrow = -1,
                     ncol = -1,
-                    rowmajor = false) where T
+                    rowmajor = false,
+                    kwargs...) where T
     nrow == -1 || nrow > 0 || throw(ArgumentError("The parameter \"nrow\" must be greater than 0"))
     ncol == -1 || ncol > 0 || throw(ArgumentError("The parameter \"ncol\" must be greater than 0"))
     npad >= 0 || throw(ArgumentError("The parameter \"npad\" must be greater than or equal to 0"))
@@ -308,22 +320,26 @@ mosaicview(As::AbstractArray...; kwargs...) = mosaicview(As; kwargs...)
 
 function mosaicview(As::AbstractVector{T};
                     fillvalue=zero(eltype(first(As))),
+                    center=true,
                     kwargs...) where {T <: AbstractArray}
     length(As) == 0 && throw(ArgumentError("The given vector should not be empty"))
     N = ndims(first(As))
     2 <= N || throw(ArgumentError("The given array must have dimensionality of N=2 or higher"))
-    mosaicview(_padded_cat(As; fillvalue=fillvalue, dims=N+1); fillvalue=fillvalue, kwargs...)
+    mosaicview(_padded_cat(As; center=center, fillvalue=fillvalue, dims=N+1);
+               fillvalue=fillvalue, kwargs...)
 end
 
-function mosaicview(As::Tuple;
+function mosaicview(As::Tuple{T, Vararg{T}};
                     fillvalue=zero(eltype(first(As))),
+                    center=true,
                     kwargs...) where {T <: AbstractArray}
     N = ndims(first(As))
     2 <= N || throw(ArgumentError("The given array must have dimensionality of N=2 or higher"))
-    mosaicview(_padded_cat(As; fillvalue=fillvalue, dims=N+1); fillvalue=fillvalue, kwargs...)
+    mosaicview(_padded_cat(As; center=center, fillvalue=fillvalue, dims=N+1);
+               fillvalue=fillvalue, kwargs...)
 end
 
-function _padded_cat(imgs; fillvalue, dims)
+function _padded_cat(imgs; center, fillvalue, dims)
     # reduce(cat, imgs) would indeed make the whole pipeline more eagerly
     # and thus allocates more memory
     # TODO: inefficient when there're too many images, e.g., 512
@@ -335,7 +351,16 @@ function _padded_cat(imgs; fillvalue, dims)
     if length(unique(map(axes, imgs))) == 1
         return cat(imgs...; dims=dims)
     else
-        cat(paddedviews(fillvalue, imgs...)...; dims=dims)
+        if center
+            # TODO: ~1.5x slower than non-centered version
+            reduce(sym_paddedviews(zero(eltype(imgs[1])), imgs...)) do x, y
+                x = OffsetArray(x, 1 .- first.(axes(x)))
+                y = OffsetArray(y, 1 .- first.(axes(y)))
+                cat(x, y; dims=dims)
+            end
+        else
+            cat(paddedviews(fillvalue, imgs...)...; dims=dims)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,6 +105,26 @@ end
         @test mosaicview(A...) == mosaicview(A)
         @test mosaicview(A..., nrow=2) == mosaicview(A, nrow=2)
         @test mosaicview(A..., nrow=2, rowmajor=true) == mosaicview(A, nrow=2, rowmajor=true)
+
+        A1 = reshape([1 2 3], (1, 3))
+        A2 = reshape([4;5;6], (3, 1))
+        @test mosaicview([A1, A2]; center=false) == [
+         1 2 3;
+         0 0 0;
+         0 0 0;
+         4 0 0;
+         5 0 0;
+         6 0 0
+        ]
+        @test mosaicview([A1, A2]; center=true) == [
+         0 0 0;
+         1 2 3;
+         0 0 0;
+         0 4 0;
+         0 5 0;
+         0 6 0
+        ]
+        @test mosaicview([A1, A2]) == mosaicview([A1, A2]; center=true)
     end
 
     @testset "3D input" begin
@@ -113,6 +133,8 @@ end
         @test_throws ArgumentError mosaicview(B, nrow=0)
         @test_throws ArgumentError mosaicview(B, ncol=0)
         @test_throws ArgumentError mosaicview(B, nrow=1, ncol=1)
+        @test mosaicview(B, center=2) == mosaicview(B) # no op
+
         mv = mosaicview(B)
         @test typeof(mv) <: MosaicView
         @test eltype(mv) == eltype(B)
@@ -146,6 +168,8 @@ end
         @test_throws ArgumentError mosaicview(A, nrow=0)
         @test_throws ArgumentError mosaicview(A, ncol=0)
         @test_throws ArgumentError mosaicview(A, nrow=1, ncol=1)
+        @test mosaicview(A, center=2) == mosaicview(A) # no op
+
         mv = mosaicview(A)
         @test mv == MosaicView(A)
         @test typeof(mv) != typeof(MosaicView(A))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -256,6 +256,10 @@ end
         mv = mosaicview(A, fillvalue=colorant"white", rowmajor=true, ncol=3)
         @test eltype(mv) == eltype(A)
         @test @inferred(getindex(mv, 3, 4)) == RGB(1,1,1)
+
+        # this should work regardless they're of different size and color
+        @test_nowarn mosaicview(rand(RGB{Float32}, 4, 4),
+                                rand(Gray{N0f8}, 5, 5))
     end
 end
 


### PR DESCRIPTION
When images are padded, they stay at the top-left corner, but for visualization purpose, it's often convenient to shift images to the center place

Note that the centered version is slower than the non-centered version, but still, I think it's worth making it as the default behavior. My argument is that we don't really care about 0.1ms, 1ms, 2ms or 10ms difference when displaying images.

Cref: this functionality builds upon [`sym_paddedviews`](https://github.com/JuliaArrays/PaddedViews.jl/pull/23)

Preview:

`mosaicview(img1, img2; nrow=1, center=true)` (default behavior)
![image](https://user-images.githubusercontent.com/8684355/76200526-c0be4700-622c-11ea-9d8f-03e22bc39be8.png)

`mosaicview(img1, img2; nrow=1, center=false)`

![image](https://user-images.githubusercontent.com/8684355/76200635-f5320300-622c-11ea-8b49-a7a718dccfb1.png)

