### PR TITLE
fix a mosaicview trivial case bug when size(A_3d, 3)==1

### DIFF
--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -257,6 +257,14 @@ function mosaicview(A::AbstractArray{T,3};
     ncol == -1 || ncol > 0 || throw(ArgumentError("The parameter \"ncol\" must be greater than 0"))
     npad >= 0 || throw(ArgumentError("The parameter \"npad\" must be greater than or equal to 0"))
     ntile = size(A,3)
+    if ntile == 1
+        # A trivial case where none of the keywords are used
+        if !(nrow in (-1, 1) && ncol in (-1, 1))
+            throw(ArgumentError("Invalid (nrow, ncol) == ($nrow, $ncol), it should be `-1` or `1`"))
+        end
+        return MosaicView(A)
+    end
+
     ntile_ceil = ntile # ntile need not be integer divideable
     if nrow == -1 && ncol == -1
         # automatically choose nrow to reflect what MosaicView does

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,6 +183,10 @@ end
         @test mosaicview(B, B) == mosaicview(cat(B, B; dims=4))
         @test mosaicview(B, B, nrow=2) == mosaicview(cat(B, B; dims=4), nrow=2)
         @test mosaicview(B, B, nrow=2, rowmajor=true) == mosaicview(cat(B, B; dims=4), nrow=2, rowmajor=true)
+
+        B = ones(Int, 3, 3, 1)
+        @test_throws ArgumentError mosaicview(B; ncol=3)
+        @test mosaicview(B) == MosaicView(B)
     end
 
     @testset "4D input" begin


### PR DESCRIPTION
None of the keyword args should be used in this trivial case.

```julia
julia> A = ones(Int, 3, 3, 1)
3×3×1 Array{Int64,3}:
[:, :, 1] =
 1  1  1
 1  1  1
 1  1  1

julia> mosaicview(A; nrow=2) # should just throw an ArgumentError
6×3 MosaicView{Int64,4,...}:
 1  1  1
 1  1  1
 1  1  1
 0  0  0
 0  0  0
 0  0  0
```