### PR TITLE
Compat for require_one_based_indexing on 1.1

### DIFF
--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -386,7 +386,7 @@ function _padded_cat(imgs; center, fillvalue, dims)
 end
 
 ### compat
-if VERSION < v"1.1"
+if VERSION <= v"1.1"
     require_one_based_indexing(A...) = !Base.has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
 else
     require_one_based_indexing = Base.require_one_based_indexing


### PR DESCRIPTION
As require_one_based_indexing is only introduced in Base in 1.2.

Closes #15 