### PR TITLE
Also use compat for Julia 1.1.1, not just 1.1.0.

### DIFF
--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -386,7 +386,7 @@ function _padded_cat(imgs; center, fillvalue, dims)
 end
 
 ### compat
-if VERSION <= v"1.1"
+if VERSION < v"1.2"
     require_one_based_indexing(A...) = !Base.has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
 else
     require_one_based_indexing = Base.require_one_based_indexing


### PR DESCRIPTION
as `v"1.1.0" <= v"1.1" == true`, but `v"1.1.1" <= v"1.1" == false`.

My bad, my previous PR #16 worked only for v"1.1.0" that I had installed locally, but that's not the latest Julia version for 1.1. v"1.1.1" still fails on the current release.
