### PR TITLE
Improve inferrability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MosaicViews"
 uuid = "e94cdb99-869f-56ef-bcf0-1ae2bcbe0389"
 authors = ["Christof Stocker <stocker.christof@gmail.com>"]
-version = "0.2.4"
+version = "0.3.0"
 
 [deps]
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 [compat]
 MappedArrays = "0.2, 0.3"
 OffsetArrays = "0.10, 0.11, 1"
-PaddedViews = "0.4, 0.5"
+PaddedViews = "0.5.8"
 julia = "1"
 
 [extras]

--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -336,7 +336,9 @@ end
     mosaic(A1, A2...; center=true, kwargs...)
     mosaic([A1, A2, ...]; center=true, kwargs...)
 
-Create a mosaic out of input arrays `A1`, `A2`, ....
+Create a mosaic out of input arrays `A1`, `A2`, .... `mosaic` is essentially
+a more flexible version of `cat` or `hvcat`; like them it makes a copy of
+the inputs rather than returning a "view."
 
 If `center` is set to `true`, then the padded arrays will be shifted
 to the center; if set to false, they shift to the top-left corner. This

--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -339,7 +339,8 @@ function mosaicview(As::AbstractVector{T};
                     center=true,
                     kwargs...) where {T <: AbstractArray}
     length(As) == 0 && throw(ArgumentError("The given vector should not be empty"))
-    length(unique(ndims.(As))) != 1 && throw(ArgumentError("All arrays should have the same dimension"))
+    nd = ndims(As[1])
+    all(A->ndims(A)==nd, As) || throw(ArgumentError("All arrays should have the same dimension"))
     N = ndims(first(As))
     mosaicview(_padded_cat(As; center=center, fillvalue=fillvalue, dims=max(3, N+1));
                fillvalue=fillvalue, kwargs...)
@@ -350,7 +351,8 @@ function mosaicview(As::Tuple;
                     center=true,
                     kwargs...)
     length(As) == 0 && throw(ArgumentError("The given tuple should not be empty"))
-    length(unique(ndims.(As))) != 1 && throw(ArgumentError("All arrays should have the same dimension"))
+    nd = ndims(As[1])
+    all(A->ndims(A)==nd, As) || throw(ArgumentError("All arrays should have the same dimension"))
     N = ndims(first(As))
     mosaicview(_padded_cat(As; center=center, fillvalue=fillvalue, dims=max(3, N+1));
                fillvalue=fillvalue, kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -333,8 +333,7 @@ end
         @test eltype(A) == Float32
         A = mosaicview(rand(Float32, 4, 4), Any[1 2 3; 4 5 6])
         @test eltype(A) == Float32
-        A = mosaicview(rand(Float64, 4, 4), Union{Missing, Float32}[1 2 3; 4 5 6])
-        @test eltype(A) == Float32
+        @test eltype(A) == Union{Missing, Float64}
     end
 end
 


### PR DESCRIPTION
This package is part of ImageCore, and because ImageCore is essentially the foundation of JuliaImages my overall goal is to set a high bar on the "engineering quality" of all packages up through ImageCore. Good inferrability = good precompilability = low latency (and good runtime performance, of course) for anyone who is building stuff based on ImageCore.

This package was the source of the large majority of inference failures while running ImageCore's test suite. This doesn't eliminate all failures but it's a pretty huge step forward: in this package's tests, it cuts it from >350 inference failures to around 100. Splatting a vector-of-arrays accounts for a good chunk of the rest, and of course no one actually has to do that (just leave as a vector-of-arrays, or construct as a tuple in the first place), so overall this seems pretty solid now. The eltype inferrability in particular is much better.

This PR is the motivation for https://github.com/JuliaArrays/OffsetArrays.jl/pull/189