### PR TITLE
more promote_wrapped_type methods for special cases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MosaicViews"
 uuid = "e94cdb99-869f-56ef-bcf0-1ae2bcbe0389"
 authors = ["Christof Stocker <stocker.christof@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"

--- a/src/MosaicViews.jl
+++ b/src/MosaicViews.jl
@@ -469,6 +469,8 @@ MosaicViews.promote_wrapped_type(::Type{S}, ::Type{MyWrapper{T}}) where {S,T} = 
 ```
 """
 promote_wrapped_type(::Type{S}, ::Type{T}) where {S, T} = promote_type(S, T)
+promote_wrapped_type(::Type{Union{}}, ::Type{T}) where T = T # easier to resolve ambiguity when extending the method
+promote_wrapped_type(::Type{T}, ::Type{T}) where T = T
 
 ### compat
 if VERSION < v"1.2"


### PR DESCRIPTION
These two special methods are needed when I try to add MosaicViews 0.3.0 support to ImageCore.